### PR TITLE
The `postCreateCommand` was failing with a 'chmod: Operation not perm…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   },
 
   // 必要なツールのインストール
-  "postCreateCommand": "bash -c 'chmod +x .devcontainer/setup.sh && .devcontainer/setup.sh'",
+  "postCreateCommand": "bash .devcontainer/setup.sh",
   
   // コンテナ起動時のメッセージ
   "postStartCommand": "echo '✅ Dev container ready! See README.md for setup instructions.'",


### PR DESCRIPTION
…itted' error. This happens because the user account inside the container doesn't have permission to change the mode of files mounted from your host.

To fix this, I have modified the command to execute the setup script directly with `bash`. This method doesn't require the executable bit to be set on the script, which avoids the permission error and allows the setup to run successfully.