### PR TITLE
I have fixed the failure in the devcontainer setup script.

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -9,7 +9,6 @@ echo "================================================"
 # 1. uvのインストール
 echo "📦 Installing uv package manager..."
 curl -LsSf https://astral.sh/uv/install.sh | sh
-source $HOME/.cargo/env
 
 # 2. Claude Code CLIのインストール
 echo "📦 Installing Claude Code CLI via npm..."


### PR DESCRIPTION
The `postCreateCommand` was failing with the error: `.devcontainer/setup.sh: line 12: /home/vscode/.cargo/env: No such file or directory`

This occurred because the script attempted to source the Cargo environment, but Rust was not installed in the dev container image. The `uv` installer downloads a pre-built binary, so the Rust toolchain is not required.

I removed the unnecessary `source $HOME/.cargo/env` line to prevent the script from failing during the dev container setup.