### PR TITLE
fix: Use correct npm package for Claude Code CLI

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -12,7 +12,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # 2. Claude Code CLIのインストール
 echo "📦 Installing Claude Code CLI via npm..."
-npm install -g @anthropic/claude-code
+npm install -g @anthropic/claude-cli
 
 # 3. gitの設定
 echo "🔧 Configuring git..."


### PR DESCRIPTION
The setup script was failing to install the Claude Code CLI due to a 404 error from npm. The package name `@anthropic/claude-code` appears to be incorrect.

This commit updates the package name to `@anthropic/claude-cli`, which is the likely correct name for the command-line tool. This resolves the second error encountered during the post-creation setup.