### PR TITLE
I've corrected the command to find the npm bin directory. The previou…

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -14,7 +14,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 echo "📦 Installing Claude Code CLI via npm..."
 npm install -g @anthropic-ai/sdk
 echo "🔎 Listing installed npm executables..."
-ls -la $(npm root -g)/.bin
+ls -la $(npm bin -g)
 
 # 3. gitの設定
 echo "🔧 Configuring git..."


### PR DESCRIPTION
…s attempt to list the installed npm executables failed because the command I was using did not point to the expected directory structure. I've now corrected the command, which is the recommended way to get the path to the npm bin directory. This should help with debugging the missing `claude` command.