### PR TITLE
I'm going to read the `package.json` file to find the executable name.

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -13,8 +13,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # 2. Claude Code CLIのインストール
 echo "📦 Installing Claude Code CLI via npm..."
 npm install -g @anthropic-ai/sdk
-echo "🔎 Listing installed npm executables..."
-ls -la $(npm bin -g)
+echo "🔎 Reading package.json to find executable name..."
+cat $(npm root -g)/@anthropic-ai/sdk/package.json
 
 # 3. gitの設定
 echo "🔧 Configuring git..."


### PR DESCRIPTION
My previous attempts to find the installed executable for `@anthropic-ai/sdk` failed.

I'll now read the `package.json` file of the installed package directly. This will allow me to inspect the `bin` field within the package definition, which should definitively identify the correct executable name.